### PR TITLE
gestalt ethic override

### DIFF
--- a/common/ethics/ethics_override.txt
+++ b/common/ethics/ethics_override.txt
@@ -1,0 +1,38 @@
+ethic_gestalt_consciousness = {
+	playable = {
+		OR = {
+			host_has_dlc = "Utopia"
+			host_has_dlc = "Synthetic Dawn Story Pack"
+		}
+	}
+
+	cost = 8
+	category = "hive"
+	category_value = 0
+	use_for_pops = no
+
+	country_modifier = {
+		country_war_exhaustion_mult = -0.2
+		country_ethic_influence_produces_add = 1
+		intel_encryption_add = 2
+	}
+
+	tags = {
+		ETHIC_GESTALT_CONSCIOUSNESS_NO_TUTORIAL
+		ETHIC_GESTALT_CONSCIOUSNESS_AUTHORITY
+		ETHIC_GESTALT_CONSCIOUSNESS_IMMORTAL_RULER
+		ETHIC_GESTALT_CONSCIOUSNESS_NO_FACTIONS
+		ETHIC_GESTALT_CONSCIOUSNESS_NO_CONSUMER_GOODS
+		ETHIC_GESTALT_CONSCIOUSNESS_DOMESTIC_POP_SURVIVAL
+		ETHIC_ALLOW_NO_RETREAT
+	}
+
+	random_weight = {
+		base = 300 #higher weight since if it's not the first ethic chosen it will never be chosen.
+		modifier = {
+			factor = 0
+			has_global_flag = game_started # additional traits (trait_hive_mind, trait_machine_unit) are only assigned and verified for empire designs, no effect after game start
+			NOT = { is_country_type = rebel }
+		}
+	}
+}


### PR DESCRIPTION
increased gestalt ethic cost to 8 to prevent of using regular ethics alongside with gestalt (which AI generated empires are tend to abuse). This creates a series of issues with vanilla triggers (is_regular_empire for example)